### PR TITLE
feat: add ori --version

### DIFF
--- a/packages/cli/__tests__/__snapshots__/cli.spec.ts.snap
+++ b/packages/cli/__tests__/__snapshots__/cli.spec.ts.snap
@@ -4,6 +4,7 @@ exports[`ori --help > A2 1`] = `
 "Usage: ori <command> [options]
 
 Options:
+  -v, --version              display version number
   -h, --help                 display help for command
 
 Commands:

--- a/packages/cli/__tests__/cli.spec.ts
+++ b/packages/cli/__tests__/cli.spec.ts
@@ -13,6 +13,7 @@ import {
 import { formatToLf } from '../src/utils/formatCrlf'
 
 const tempDir = path.resolve(__dirname, '../../temp')
+const version = require('../package.json').version
 
 beforeAll(async () => {
   await fs.mkdirp(tempDir)
@@ -20,6 +21,12 @@ beforeAll(async () => {
 
 afterAll(() => {
   fs.removeSync(tempDir)
+})
+
+test('ori --version', () => {
+  const { stdout, status } = runSync(['--version'])
+  expect(stdout).toContain(version)
+  expect(status).toEqual(0)
 })
 
 test('ori --help', () => {

--- a/packages/cli/bin/ori.ts
+++ b/packages/cli/bin/ori.ts
@@ -5,7 +5,12 @@ import { codemod, codemodHelp } from '../src/commands/codmod'
 import { toVite, toViteHelp } from '../src/commands/webpackToVite'
 const { dev, build } = require('@originjs/cli-service')
 const program = new Command()
+const version = require('../package.json').version
 
+program
+  .name('ori')
+  .usage('<command> [options]')
+  .version(version, '-v, --version', 'display version number')
 program.name('ori').usage('<command> [options]')
 program
   .command('init <app-name>')


### PR DESCRIPTION
Use the `ori --version` command to view the current version.