### PR TITLE
fix wrong URL

### DIFF
--- a/packages/cli/oriTemplate/src/layouts/__default.vue
+++ b/packages/cli/oriTemplate/src/layouts/__default.vue
@@ -32,7 +32,7 @@ export default {
       },
       {
         title: 'docs',
-        link: 'https://originjs.github.io/docs/'
+        link: 'https://originjs.github.io/en/guide/'
       }
     ])
 


### PR DESCRIPTION
`https://originjs.github.io/docs/` is returning 404